### PR TITLE
Uninstall completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img src="demo.gif" width="690">
 
 * Makes `npm install` recommendations from npm cache
+* Makes `npm uninstall` recommendations from `dependencies`/`devDependencies`
 * Shows detailed information on script contents for `npm run`
 * Falls back to default npm completions if we don't have anything better
 

--- a/zsh-better-npm-completion.plugin.zsh
+++ b/zsh-better-npm-completion.plugin.zsh
@@ -2,6 +2,10 @@ _zbnc_npm_command() {
   echo "${words[2]}"
 }
 
+_zbnc_npm_command_arg() {
+  echo "${words[3]}"
+}
+
 _zbnc_no_of_npm_args() {
   echo "$#words"
 }
@@ -65,6 +69,9 @@ _zbnc_npm_install_completion() {
 }
 
 _zbnc_npm_uninstall_completion() {
+
+  # Use default npm completion to recommend global modules
+  [[ "$(_zbnc_npm_command_arg)" = "-g" ]] ||  [[ "$(_zbnc_npm_command_arg)" = "--global" ]] && return
 
   # Look for a package.json file
   local package_json="$(_zbnc_recursively_look_for package.json)"


### PR DESCRIPTION
Makes `npm uninstall` recommendations from `dependencies`/`devDependencies` form the first `package.json` file we can find. If we can't find one it'll default to cached modules.

`npm uninstall -g|--global` will fall back to default `npm` completion and recommend globally installed modules.